### PR TITLE
Updated folder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Slideshow Card for Home Assistant's UI LoveLace
 | fill | boolean | **Optional** | Makes the inner Cards fill the container, `Default: false`
 | auto_play | boolean | **Optional** | Option to turn on/off auto switching of the cards, `Default: false`
 | auto_delay | string | **Optional** | Seconds between switching to next card when autoplay=true, `Default: 5`
+| no_fade | boolean | **Optional** | Set to true to prevent a fade between each card, `Default: false`
 | folder | entity | **Optional** | This is for dynamically pulling images from a folder `See Dynamic Slideshow`
+| folder_sort | boolean | **Optional** | If true, will sort the flie list by name `Default: false`
 
 
 ## Added Child Card Variables
@@ -31,28 +33,24 @@ Slideshow Card for Home Assistant's UI LoveLace
 
 This allows you add images to a folder in your WWW folder that contains images you would like the see in the slideshow. Currently, this requires over writing the Folder Sensor so that the client can see the files. I am working on a built in method but wanted to get this feature available.
 
-You will need to create a folder in your config directory named `custom_components`, within the custom_components folder you will need to create a `sensor` folder, and within that folder copy the `folder.py` file. 
-
-1. Create a folder in your `config` directory named `custom_components`
-2. Create a folder in your `custom_components` named `sensor`
-3. Copy the `folder.py` into the `sensor` folder
-4. Add the folder sensor to your configuration.yaml file
+1. Add the folder sensor to your configuration.yaml file
     ```yaml
     - sensor
         - platform: folder
           folder: /config/www/images
     ```
-5. Create a folder in your `WWW` folder named `images`
-6. Add your images to this folder
-7. Restart Home Assistant
-8. Check the sensor.images entity to see if the `file_list` attribute lists your image files
-9. Add a card to your ui-lovelace.yaml
+2. Create a folder in your `WWW` folder named `images`
+3. Add your images to this folder
+4. Restart Home Assistant
+5. Check the sensor.images entity to see if the `file_list` attribute lists your image files
+6. Add a card to your ui-lovelace.yaml
     ```yaml
     - type: custom:slideshow-card
       folder: sensor.images
     ```
     * The other configuration variables are still available to use
-10. Refresh your Lovelace Frontend
+    * You will need at least one card defined
+7. Refresh your Lovelace Frontend
 
 Any files you add to the folder should automatically get added to the slide show
 
@@ -165,7 +163,7 @@ Thank you to @thomasloven for his [Custom Cards](https://community.home-assistan
 
 ## Updates
 
-Breaking Changes: 
+Breaking Changes:
 
     * Flush has been replaced with fill
     * arrowcolor has been replaced with arrow_color

--- a/slideshow-card.js
+++ b/slideshow-card.js
@@ -5,7 +5,7 @@ class SlideshowCard extends Polymer.Element {
   constructor() {
     super();
     this.slideIndex = 1;
-    this.attachShadow({ mode: 'open' });    
+    this.attachShadow({ mode: 'open' });
   }
 
   async ready() {
@@ -48,9 +48,12 @@ class SlideshowCard extends Polymer.Element {
 
       if(hass.states[this.config.folder]) {
         this.images = hass.states[this.config.folder].attributes.file_list;
-        hass.states[this.config.folder].attributes.file_list.forEach(item => {
+        if (this.config.folder_sort) {
+          this.images.sort()
+        }
+        this.images.forEach(item => {
           const image = document.createElement('img');
-          var fileLocation = item.substring(11);
+          var fileLocation = item.substring(item.indexOf("www")+3);
           image.setAttribute("src", "/local" + fileLocation);
           image.className = 'slides fade';
           image.style.setProperty("width", "100%");
@@ -68,10 +71,14 @@ class SlideshowCard extends Polymer.Element {
           item.hass = hass;
         });
       if(hass.states[this.config.folder]){
-        hass.states[this.config.folder].attributes.file_list.forEach(item => {
+        this.images = hass.states[this.config.folder].attributes.file_list;
+        if (this.config.folder_sort) {
+          this.images.sort()
+        }
+        this.images.forEach(item => {
           if(!this.images.includes(item)){
             const image = document.createElement('img');
-            var fileLocation = item.substring(11);
+            var fileLocation = item.substring(item.indexOf("www")+3);
             image.setAttribute("src", "/local" + fileLocation);
             image.className = 'slides fade';
             image.style.setProperty("width", "100%");
@@ -91,9 +98,14 @@ class SlideshowCard extends Polymer.Element {
     this.config = config;
 
     if (!config || (!config.folder && (!config.cards || !Array.isArray(config.cards) || config.cards.length < 2))) {
-      throw new Error('Card Configuration is not set up properly!');
+      throw new Error('Card Configuration is not set up properly - no cards!');
     }
-      
+    
+    if (!config || (config.folder && (!config.cards || !Array.isArray(config.cards) || config.cards.length < 1))) {
+      throw new Error('Card Configuration is not set up properly - folder option needs at least 1 card!');
+    }
+
+
     this._cards = config.cards.map(async (item) => {
       let element;
       const helper = await window.loadCardHelpers();
@@ -155,9 +167,9 @@ class SlideshowCard extends Polymer.Element {
 
       .fade {
         -webkit-animation-name: fade;
-        -webkit-animation-duration: 1s;
+        -webkit-animation-duration: DURATION;
         animation-name: fade;
-        animation-duration: 1s;
+        animation-duration: DURATION;
       }
 
       @-webkit-keyframes fade {
@@ -170,6 +182,11 @@ class SlideshowCard extends Polymer.Element {
         to {opacity: 1}
       }
     `;
+    if (this.config.no_fade) {
+      style.innerHTML = style.innerHTML.replace("DURATION","0")
+    } else {
+      style.innerHTML = style.innerHTML.replace("DURATION","1s")
+    }
     this.card.appendChild(style);
   }
 
@@ -202,7 +219,7 @@ class SlideshowCard extends Polymer.Element {
             
           }
         }
-        item.style.setProperty('box-shadow', 'none');  
+        item.style.setProperty('box-shadow', 'none');
       });
       
     }


### PR DESCRIPTION
Hello,

I've made a few changes to upgrade the folder support.

1) It seems to need at least 1 card is needed in folder support, so I now raise an error in no cards are configured.
2) The config assumes the folder is `/config/www` but in Python VENV deployments this is not true - resolved.
3) Enhancement: option sort the file names in a folder - useful for sequences of `image001,jpg`, `image002,jpg`...
4) Enhancement: option to stop the fade between images [Issue #2](https://github.com/igloo15/slideshow-card/issues/2)
5) Changed the documentation about the need to create the custom_configuration - the version built in to HASS seem to work just fine.

